### PR TITLE
Allow running functions on cloned path

### DIFF
--- a/ghq.el
+++ b/ghq.el
@@ -1,5 +1,8 @@
 ;;; ghq.el --- Ghq interface for emacs -*- lexical-binding: t -*-
 
+;; Copyright (C) 2015 Roman Coedo
+;; Copyright (C) 2021 Joseph LaFreniere
+
 ;; Author: Roman Coedo <romancoedo@gmail.com>
 ;; Created 28 November 2015
 ;; Version: 0.1.3
@@ -32,6 +35,8 @@
 ;; Boston, MA 02110-1301, USA.
 
 ;;; Code:
+(require 'simple)
+
 (defun ghq--find-root ()
   "Find the ghq root directory."
   (car (split-string (shell-command-to-string "ghq root"))))

--- a/ghq.el
+++ b/ghq.el
@@ -80,6 +80,7 @@
          (setq path (match-string 1))
          (message "%s cloned to %s" repository path))))))
 
+;;;###autoload
 (defun ghq-ssh ()
   "Clone a repository via ghq over SSH."
   (interactive)


### PR DESCRIPTION
This is useful for doing things like automatically adding the cloned path to `projectile-known-projects`.